### PR TITLE
Format key

### DIFF
--- a/lib/rsautl.js
+++ b/lib/rsautl.js
@@ -16,6 +16,29 @@ function verifyOptions (options) {
     }
 }
 
+function formatKey (key) {
+    if (key.indexOf('-----BEGIN') === -1 || key.indexOf('-----END') === -1) {
+        return key;
+    }
+
+    var begin = key.substring(0, key.indexOf('KEY-----') + 'KEY-----'.length);
+    var end = key.substring(key.indexOf('-----END'));
+    var body = key.substring(begin.length, key.length - end.length).replace(/(\r\n|\n|\r)/gm, '');
+
+    key = begin + '\n';
+    for (var i = 0; i < body.length; i += 64) {
+        if (body.length - i < 64) {
+            key += body.substring(i);
+        } else {
+            key += body.substring(i, i + 64);
+        }
+        key += '\n';
+    }
+    key += end;
+
+    return key;
+}
+
 function operation (data, key, callback, options) {
     var options = options || {};
 
@@ -27,7 +50,7 @@ function operation (data, key, callback, options) {
 
     try {
         verifyOptions(options);
-        run(options, data, key, callback);
+        run(options, data, formatKey(key), callback);
     } catch (err) {
         return callback(err);
     }

--- a/test/operations.js
+++ b/test/operations.js
@@ -54,3 +54,41 @@ exports.signAndVerify = function (test) {
 
     setTimeout(function () { test.done(); }, 500); // Allow for IO and computations to complete
 }
+
+exports.formatKey = function (test) {
+    var testStr = 'Unformatted keys';
+    var unformattedPublicKey = publicKey.replace(/\n/gm, '');
+    var unformattedPrivateKey = privateKey.replace(/\n/gm, '');
+
+    test.expect(5);
+    test.ok(unformattedPublicKey !== publicKey, 'Unformatted public key matches formatted original');
+    test.ok(unformattedPrivateKey !== privateKey, 'Unformatted private key matches formatted original');
+    rsautl.encrypt(testStr, unformattedPublicKey, function (err, encrypted) {
+        test.ok(err === null, err);
+        rsautl.decrypt(encrypted, unformattedPrivateKey, function (err, decrypted) {
+            test.ok(err === null, err);
+            test.ok(decrypted === testStr, 'Encrypted/decrypted mismatch');
+        });
+    });
+
+    setTimeout(function () { test.done(); }, 500); // Allow for IO and computations to complete
+}
+
+exports.formatKeyWithWindowsLineEndings = function (test) {
+    var testStr = 'Keys with Windows line endings';
+    var windowsPublicKey = publicKey.replace(/\n/gm, '\r\n');
+    var windowsPrivateKey = privateKey.replace(/\n/gm, '\r\n');
+
+    test.expect(5);
+    test.ok(windowsPublicKey !== publicKey, 'Public key with Windows line endings matches original');
+    test.ok(windowsPrivateKey !== privateKey, 'Private key with Windows line endings matches original');
+    rsautl.encrypt(testStr, windowsPublicKey, function (err, encrypted) {
+        test.ok(err === null, err);
+        rsautl.decrypt(encrypted, windowsPrivateKey, function (err, decrypted) {
+            test.ok(err === null, err);
+            test.ok(decrypted === testStr, 'Encrypted/decrypted mismatch');
+        });
+    });
+
+    setTimeout(function () { test.done(); }, 500); // Allow for IO and computations to complete
+}


### PR DESCRIPTION
Unless key is properly formatted, executing `/usr/bin/openssl rsautl …`
will fail and report error “unable to load Private Key”.