### PR TITLE
Only invoke the callback once the unlink operation has completed.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -16,8 +16,9 @@ module.exports = function (options, data, key, callback) {
 
     fs.writeFile(tmpFile, key, function (err) {
         if (err) {
-            fs.unlink(tmpFile);
-            return callback(err);
+            return fs.unlink(tmpFile, function() {
+                callback(err);
+             });
         }
 
         var execOpts = { encoding: 'utf8' };
@@ -27,12 +28,14 @@ module.exports = function (options, data, key, callback) {
 
         var proc = exec(cmdline, execOpts, function (err, stdout, stderr) {
             if (err) {
-                fs.unlink(tmpFile);
-                return callback(err);
+                return fs.unlink(tmpFile, function() {
+                    callback(err);
+                });
             }
 
-            callback(null, stdout);
-            fs.unlink(tmpFile);
+            fs.unlink(tmpFile, function() {
+                callback(null, stdout);
+             });
         });
 
         if (options.operation === 'decrypt' || options.operation === 'verify') {


### PR DESCRIPTION
This also removes the exception through by unlink not having a
valid callback of its own.